### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,10 @@
 sirikali (1.4.6-1) UNRELEASED; urgency=medium
 
+  [ David Steele ]
   * New upstream version.
+
+  [ Debian Janitor ]
+  * Use secure URI in Homepage field.
 
  -- David Steele <steele@debian.org>  Fri, 07 Aug 2020 22:07:17 -0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ sirikali (1.4.6-1) UNRELEASED; urgency=medium
 
   [ Debian Janitor ]
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Submit.
 
  -- David Steele <steele@debian.org>  Fri, 07 Aug 2020 22:07:17 -0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ sirikali (1.4.6-1) UNRELEASED; urgency=medium
   [ Debian Janitor ]
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Bug-Submit.
+  * Remove obsolete field Name from debian/upstream/metadata (already present in
+    machine-readable debian/copyright).
 
  -- David Steele <steele@debian.org>  Fri, 07 Aug 2020 22:07:17 -0400
 

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper-compat (= 13),
                bzip2,
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: http://mhogomchungu.github.io/sirikali
+Homepage: https://mhogomchungu.github.io/sirikali
 Vcs-Git: https://github.com/davesteele/sirikali.git -b debian
 Vcs-Browser: https://github.com/davesteele/sirikali
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,5 @@
 Name: SiriKali
+Bug-Submit: https://github.com/mhogomchungu/sirikali/issues/new
 Repository: https://github.com/mhogomchungu/sirikali.git
 Repository-Browse: https://github.com/mhogomchungu/sirikali
 Homepage: https://mhogomchungu.github.io/sirikali/

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,3 @@
-Name: SiriKali
 Bug-Submit: https://github.com/mhogomchungu/sirikali/issues/new
 Repository: https://github.com/mhogomchungu/sirikali.git
 Repository-Browse: https://github.com/mhogomchungu/sirikali


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/sirikali/1f54c946-a7ea-4ac7-a659-6468960404a2.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package sirikali: lines which differ (wdiff format)
* Homepage: [-http&#8203;://mhogomchungu.github.io/sirikali-] {+https&#8203;://mhogomchungu.github.io/sirikali+}

No differences were encountered between the control files of package \*\*sirikali-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1f54c946-a7ea-4ac7-a659-6468960404a2/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1f54c946-a7ea-4ac7-a659-6468960404a2/diffoscope)).
