### PR TITLE
preinst: check for pidof existence before calling it

### DIFF
--- a/debian/sirikali.preinst
+++ b/debian/sirikali.preinst
@@ -4,7 +4,7 @@ set -e
 
 case "$1" in
     upgrade)
-        if pidof sirikali ; then
+        if command -v pidof >/dev/null 2>&1 && pidof sirikali ; then
             echo "********************************************"
             echo "Sirikali must not be running when upgrading!"
             echo "********************************************"


### PR DESCRIPTION
pidof is being removed from the essential set, to shrink it. It will be available on the vast majority of systems, especially full desktop ones, but to be safe check if it exists before calling it in preinst.